### PR TITLE
refactor: improve readability of URLs in gpt summarization

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -230,6 +230,10 @@ func actionGPTTranslate(event *linebot.Event, values url.Values) {
 	log.Println("actionGPTTranslate: url=", url)
 	result := getArticleByURL(url)
 	gptRet := gptCompleteContext(fmt.Sprintf(`幫我將以下內容做中文摘要: ---\n %s---"`, result[0].Summary.Body))
+
+	//Doing url handle if it in gpt summarization.
+	gptRet = AddLineBreaksAroundURLs(gptRet)
+
 	if _, err := bot.ReplyMessage(event.ReplyToken, linebot.NewTextMessage(gptRet)).Do(); err != nil {
 		log.Println(err)
 	}

--- a/tools.go
+++ b/tools.go
@@ -3,6 +3,7 @@ package main
 import (
 	"math/rand"
 	"reflect"
+	"regexp"
 	"time"
 
 	"github.com/line/line-bot-sdk-go/v7/linebot"
@@ -60,4 +61,12 @@ func GetRandomIntSet(max int, count int) (randInts []int) {
 	list := rand.Perm(max)
 	randInts = list[:count]
 	return randInts
+}
+
+// AddLineBreaksAroundURLs takes a string as input, finds URLs,
+// and inserts a newline character before and after each URL.
+// It returns the modified string.
+func AddLineBreaksAroundURLs(input string) string {
+	re := regexp.MustCompile(`(https?:\/\/[^\s\p{Han}]+)`)
+	return re.ReplaceAllString(input, "\n$1\n")
 }


### PR DESCRIPTION
- Add `AddLineBreaksAroundURLs` function to insert newlines around URLs for better readability
- Update `actionGPTTranslate` to use `AddLineBreaksAroundURLs` for URL handling in gpt summarization.